### PR TITLE
Fix setting default-directory

### DIFF
--- a/karma.el
+++ b/karma.el
@@ -119,7 +119,7 @@
   (let ((project-root (karma-project-root)))
     (if (not project-root)
         (error "Couldn't find any project root")
-      (setq default-directory project-root))))
+      (setq default-directory (file-name-as-directory project-root)))))
 
 (defvar karma-buffer--buffer-name nil
   "Used to store compilation name so recompilation works as expected.")


### PR DESCRIPTION
Documentation for default-directory says:

"Name of default directory of current buffer.  Should end with slash."

This change should ensure that the value being set as the
default-directory is styled as a directory name
